### PR TITLE
Added support for selectors #206 #207 #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 - General improvements:
-  - Updated PSRule options schema to support conventions. [#199](https://github.com/Microsoft/PSRule-vscode/issues/199)
+  - Added support for configuring conventions. [#199](https://github.com/Microsoft/PSRule-vscode/issues/199)
+  - Added support for selectors. [#206](https://github.com/Microsoft/PSRule-vscode/issues/206)
+  - Updated options and language schema to support `binding.preferTargetInfo` option. [#207](https://github.com/Microsoft/PSRule-vscode/issues/207)
+  - Updated language schema to add `apiVersion` property. [#208](https://github.com/Microsoft/PSRule-vscode/issues/208)
 - Engineering:
   - Bump vscode engine to v1.54.0. [#193](https://github.com/microsoft/PSRule-vscode/pull/193)
 
@@ -21,8 +24,8 @@ What's changed since v0.16.0:
 What's changed since v0.15.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.21.0. [#135](https://github.com/Microsoft/PSRule-vscode/issues/135)
-  - Updated PSRule resource schema to v0.21.0. [#134](https://github.com/Microsoft/PSRule-vscode/issues/134)
+  - Updated options schema to v0.21.0. [#135](https://github.com/Microsoft/PSRule-vscode/issues/135)
+  - Updated language schema to v0.21.0. [#134](https://github.com/Microsoft/PSRule-vscode/issues/134)
 - Engineering:
   - Bump vscode engine to v1.50.0.
 
@@ -31,8 +34,8 @@ What's changed since v0.15.0:
 What's changed since v0.14.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.20.0. [#106](https://github.com/Microsoft/PSRule-vscode/issues/106)
-  - Updated PSRule resource schema to v0.20.0. [#107](https://github.com/Microsoft/PSRule-vscode/issues/107)
+  - Updated options schema to v0.20.0. [#106](https://github.com/Microsoft/PSRule-vscode/issues/106)
+  - Updated language schema to v0.20.0. [#107](https://github.com/Microsoft/PSRule-vscode/issues/107)
 - Engineering:
   - Bump vscode engine to v1.49.0.
 
@@ -41,7 +44,7 @@ What's changed since v0.14.0:
 What's changed since v0.13.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.19.0. [#87](https://github.com/Microsoft/PSRule-vscode/issues/87)
+  - Updated options schema to v0.19.0. [#87](https://github.com/Microsoft/PSRule-vscode/issues/87)
 
 ## v0.13.0
 
@@ -50,21 +53,21 @@ What's changed since v0.12.0:
 - New features:
   - Added snippet for ModuleConfig resource. [#75](https://github.com/Microsoft/PSRule-vscode/issues/75)
 - General improvements:
-  - Updated PSRule resource schema to v0.17.0. [#73](https://github.com/Microsoft/PSRule-vscode/issues/73)
+  - Updated language schema to v0.17.0. [#73](https://github.com/Microsoft/PSRule-vscode/issues/73)
 
 ## v0.12.0
 
 What's changed since v0.11.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.16.0. [#68](https://github.com/Microsoft/PSRule-vscode/issues/68)
+  - Updated options schema to v0.16.0. [#68](https://github.com/Microsoft/PSRule-vscode/issues/68)
 
 ## v0.11.0
 
 What's changed since v0.10.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.14.0. [#63](https://github.com/Microsoft/PSRule-vscode/issues/63)
+  - Updated options schema to v0.14.0. [#63](https://github.com/Microsoft/PSRule-vscode/issues/63)
 
 ## v0.10.0
 
@@ -72,39 +75,39 @@ What's changed since v0.9.0:
 
 - General improvements:
   - Updated markdown snippet to include links section and online version. [#60](https://github.com/Microsoft/PSRule-vscode/issues/60)
-  - Updated PSRule options schema to v0.13.0. [#59](https://github.com/Microsoft/PSRule-vscode/issues/59)
+  - Updated options schema to v0.13.0. [#59](https://github.com/Microsoft/PSRule-vscode/issues/59)
 
 ## v0.9.0
 
 What's changed since v0.8.0:
 
 - General improvements:
-  - Updated PSRule schemas to v0.12.0. [#54](https://github.com/Microsoft/PSRule-vscode/issues/54)
+  - Updated schemas to v0.12.0. [#54](https://github.com/Microsoft/PSRule-vscode/issues/54)
 
 ## v0.8.0
 
 What's changed since v0.7.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.11.0. [#49](https://github.com/Microsoft/PSRule-vscode/issues/49)
+  - Updated options schema to v0.11.0. [#49](https://github.com/Microsoft/PSRule-vscode/issues/49)
 
 ## v0.7.0
 
 What's changed since v0.6.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.10.0. [#44](https://github.com/Microsoft/PSRule-vscode/issues/44)
+  - Updated options schema to v0.10.0. [#44](https://github.com/Microsoft/PSRule-vscode/issues/44)
 
 ## v0.6.0
 
 What's changed since v0.5.0:
 
 - New features:
-  - Added PSRule resource schema. [#39](https://github.com/Microsoft/PSRule-vscode/issues/39)
+  - Added language schema. [#39](https://github.com/Microsoft/PSRule-vscode/issues/39)
   - Added snippet for baseline resource. [#40](https://github.com/Microsoft/PSRule-vscode/issues/40)
   - Added highlighting for `Synopsis:` resource comments. [#41](https://github.com/Microsoft/PSRule-vscode/issues/41)
 - General improvements:
-  - Updated PSRule options schema to v0.9.0. [#38](https://github.com/Microsoft/PSRule-vscode/issues/38)
+  - Updated options schema to v0.9.0. [#38](https://github.com/Microsoft/PSRule-vscode/issues/38)
 
 ## v0.5.0
 
@@ -113,14 +116,14 @@ What's changed since v0.4.0:
 - New features:
   - Added snippet and syntax support for Reason keyword. [#32](https://github.com/Microsoft/PSRule-vscode/issues/32)
 - General improvements:
-  - Updated PSRule options schema to v0.8.0. [#31](https://github.com/Microsoft/PSRule-vscode/issues/31)
+  - Updated options schema to v0.8.0. [#31](https://github.com/Microsoft/PSRule-vscode/issues/31)
 
 ## v0.4.0
 
 What's changed since v0.3.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.7.0. [#26](https://github.com/Microsoft/PSRule-vscode/issues/26)
+  - Updated options schema to v0.7.0. [#26](https://github.com/Microsoft/PSRule-vscode/issues/26)
 
 ## v0.3.0
 
@@ -136,7 +139,7 @@ What's changed since v0.2.0:
 What's changed since v0.1.0:
 
 - General improvements:
-  - Updated PSRule options schema to v0.5.0. [#12](https://github.com/Microsoft/PSRule-vscode/issues/12)
+  - Updated options schema to v0.5.0. [#12](https://github.com/Microsoft/PSRule-vscode/issues/12)
 - Bug fixes:
   - Fixed CI badge not displaying in VSCode extension tab. [#8](https://github.com/Microsoft/PSRule-vscode/issues/8)
   - Fixed syntax highlighting for keywords that are included in comments. [#10](https://github.com/Microsoft/PSRule-vscode/issues/10)

--- a/docs/example.Rule.ps1
+++ b/docs/example.Rule.ps1
@@ -11,7 +11,7 @@ Rule 'redis.NonSslPort' -If { ResourceType 'Microsoft.Cache/Redis' } {
 }
 
 # Synopsis: Redis Cache should reject TLS versions older then 1.2
-Rule 'redis.MinTLS' -If { ResourceType 'Microsoft.Cache/Redis' } {
+Rule 'redis.MinTLS' -Type 'Microsoft.Cache/Redis' {
     Recommend 'Enforce TLS 1.2 unless required to support older tools.'
 
     # Check that TLS is within range

--- a/docs/example.Rule.yaml
+++ b/docs/example.Rule.yaml
@@ -1,6 +1,7 @@
 
 ---
-# Synopsis: This is an example baseline
+# Synopsis: An example baseline
+apiVersion: github.com/microsoft/PSRule/v1
 kind: Baseline
 metadata:
   name: ExampleBaseline
@@ -8,3 +9,32 @@ spec:
   rule:
     exclude:
     - Rule1
+
+---
+# Synopsis: An example module configuration
+apiVersion: github.com/microsoft/PSRule/v1
+kind: ModuleConfig
+metadata:
+  name: ExampleConfiguration
+spec:
+  binding: { }
+  configuration: { }
+  output:
+    culture:
+    - en-US
+
+---
+# Synopsis: An example selector
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: ExampleSelector
+spec:
+  if:
+    allOf:
+    - field: Name
+      equals: TargetObject1
+    - field: Value
+      equals: value1
+
+

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1,13 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "PSRule language",
-    "description": "A schema for PSRule YAML language files.",
     "oneOf": [
         {
-            "$ref": "#/definitions/baseline"
+            "$ref": "#/definitions/baseline-v1"
         },
         {
-            "$ref": "#/definitions/moduleConfig"
+            "$ref": "#/definitions/moduleConfig-v1"
+        },
+        {
+            "$ref": "#/definitions/selector-v1"
         }
     ],
     "definitions": {
@@ -31,12 +32,20 @@
                 "name"
             ]
         },
-        "baseline": {
+        "baseline-v1": {
             "type": "object",
             "title": "Baseline",
             "description": "A PSRule Baseline.",
             "markdownDescription": "A PSRule Baseline. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Baseline.html)",
             "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "title": "API Version",
+                    "description": "The API Version for the PSRule resources.",
+                    "enum": [
+                        "github.com/microsoft/PSRule/v1"
+                    ]
+                },
                 "kind": {
                     "type": "string",
                     "title": "Kind",
@@ -56,6 +65,7 @@
                 }
             },
             "required": [
+                "apiVersion",
                 "kind",
                 "metadata",
                 "spec"
@@ -64,7 +74,7 @@
         },
         "baselineSpec": {
             "type": "object",
-            "title": "Baseline",
+            "title": "Spec",
             "description": "A specification for a baseline.",
             "markdownDescription": "A specification for a baseline. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Baseline.html)",
             "properties": {
@@ -121,11 +131,19 @@
             },
             "additionalProperties": false
         },
-        "moduleConfig": {
+        "moduleConfig-v1": {
             "type": "object",
             "title": "ModuleConfig",
             "description": "A PSRule ModuleConfig.",
             "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "title": "API Version",
+                    "description": "The API Version for the PSRule resources.",
+                    "enum": [
+                        "github.com/microsoft/PSRule/v1"
+                    ]
+                },
                 "kind": {
                     "type": "string",
                     "title": "Kind",
@@ -144,6 +162,7 @@
                 }
             },
             "required": [
+                "apiVersion",
                 "kind",
                 "metadata",
                 "spec"
@@ -152,7 +171,7 @@
         },
         "moduleConfigSpec": {
             "type": "object",
-            "title": "ModuleConfig",
+            "title": "Spec",
             "description": "A specification for a ModuleConfig.",
             "properties": {
                 "binding": {
@@ -253,6 +272,13 @@
                     "markdownDescription": "Configures the separator to use for building a qualified name. The default is `/`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingnameseparator)",
                     "default": "/"
                 },
+                "preferTargetInfo": {
+                    "type": "boolean",
+                    "title": "Prefer target info",
+                    "description": "Determines if binding prefers target info provided by the object over custom configuration. The default is false.",
+                    "markdownDescription": "Determines if binding prefers target info provided by the object over custom configuration. The default is `false`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingprefertargetinfo)",
+                    "default": false
+                },
                 "targetName": {
                     "type": "array",
                     "title": "Bind TargetName",
@@ -306,6 +332,7 @@
                     "type": "array",
                     "title": "Include conventions",
                     "description": "An ordered list of conventions to include.",
+                    "markdownDescription": "An ordered list of conventions to include. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#conventioninclude)",
                     "items": {
                         "type": "string"
                     },
@@ -313,6 +340,455 @@
                 }
             },
             "additionalProperties": false
+        },
+        "selector-v1": {
+            "type": "object",
+            "title": "Selector",
+            "description": "A PSRule Selector.",
+            "markdownDescription": "A PSRule Selector. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html)",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "title": "API Version",
+                    "description": "The API Version for the PSRule resources.",
+                    "enum": [
+                        "github.com/microsoft/PSRule/v1"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "Kind",
+                    "description": "A PSRule Selector resource.",
+                    "enum": [
+                        "Selector"
+                    ]
+                },
+                "metadata": {
+                    "type": "object",
+                    "$ref": "#/definitions/resource-metadata"
+                },
+                "spec": {
+                    "type": "object",
+                    "$ref": "#/definitions/selectorSpec"
+                }
+            },
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ]
+        },
+        "selectorSpec": {
+            "type": "object",
+            "title": "Spec",
+            "description": "PSRule selector specification.",
+            "properties": {
+                "if": {
+                    "type": "object",
+                    "$ref": "#/definitions/selectorExpression"
+                }
+            },
+            "required": [
+                "if"
+            ],
+            "additionalProperties": false
+        },
+        "selectorExpression": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorOperator"
+                },
+                {
+                    "$ref": "#/definitions/selectorCondition"
+                }
+            ]
+        },
+        "selectorOperator": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorOperatorAllOf"
+                },
+                {
+                    "$ref": "#/definitions/selectorOperatorAnyOf"
+                },
+                {
+                    "$ref": "#/definitions/selectorOperatorNot"
+                }
+            ]
+        },
+        "selectorCondition": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorConditionExists"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionEquals"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionNotEquals"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionHasValue"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionMatch"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionNotMatch"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionIn"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionNotIn"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionLess"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionLessOrEquals"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionGreater"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionGreaterOrEquals"
+                }
+            ]
+        },
+        "selectorProperties": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "field": {
+                            "type": "string",
+                            "title": "Field",
+                            "description": "The path of the field.",
+                            "markdownDescription": "The path of the field. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#field)"
+                        }
+                    },
+                    "required": [
+                        "field"
+                    ]
+                }
+            ]
+        },
+        "selectorOperatorAllOf": {
+            "type": "object",
+            "properties": {
+                "allOf": {
+                    "type": "array",
+                    "title": "AllOf",
+                    "description": "All of the expressions must be true.",
+                    "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#allof)",
+                    "items": {
+                        "$ref": "#/definitions/selectorExpression"
+                    }
+                }
+            },
+            "required": [
+                "allOf"
+            ],
+            "additionalProperties": false
+        },
+        "selectorOperatorAnyOf": {
+            "type": "object",
+            "properties": {
+                "anyOf": {
+                    "type": "array",
+                    "title": "AnyOf",
+                    "description": "One of the expressions must be true.",
+                    "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#anyof)",
+                    "items": {
+                        "$ref": "#/definitions/selectorExpression"
+                    }
+                }
+            },
+            "required": [
+                "anyOf"
+            ],
+            "additionalProperties": false
+        },
+        "selectorOperatorNot": {
+            "type": "object",
+            "properties": {
+                "not": {
+                    "type": "object",
+                    "title": "Not",
+                    "description": "The nested expression must not be true.",
+                    "markdownDescription": "The nested expression must not be true. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#not)",
+                    "$ref": "#/definitions/selectorExpression"
+                }
+            },
+            "required": [
+                "not"
+            ]
+        },
+        "selectorConditionExists": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean",
+                    "title": "Exists",
+                    "description": "Must have the named field.",
+                    "markdownDescription": "Must have the named field. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#exists)"
+                },
+                "field": {
+                    "type": "string",
+                    "title": "Field",
+                    "description": "The path of the field.",
+                    "markdownDescription": "The path of the field. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#field)"
+                }
+            },
+            "required": [
+                "exists",
+                "field"
+            ]
+        },
+        "selectorConditionEquals": {
+            "type": "object",
+            "properties": {
+                "equals": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "title": "Equals",
+                            "description": "Must have the specified value.",
+                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
+                        },
+                        {
+                            "type": "integer",
+                            "title": "Equals",
+                            "description": "Must have the specified value.",
+                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
+                        },
+                        {
+                            "type": "boolean",
+                            "title": "Equals",
+                            "description": "Must have the specified value.",
+                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "equals"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionNotEquals": {
+            "type": "object",
+            "properties": {
+                "notEquals": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "title": "Not Equals",
+                            "description": "Must not have the specified value.",
+                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
+                        },
+                        {
+                            "type": "integer",
+                            "title": "Not Equals",
+                            "description": "Must not have the specified value.",
+                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
+                        },
+                        {
+                            "type": "boolean",
+                            "title": "Not Equals",
+                            "description": "Must not have the specified value.",
+                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "notEquals"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionHasValue": {
+            "type": "object",
+            "properties": {
+                "hasValue": {
+                    "type": "boolean",
+                    "title": "Has Value",
+                    "description": "Must have a non-empty value.",
+                    "markdownDescription": "Must have a non-empty value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasvalue)"
+                }
+            },
+            "required": [
+                "hasValue"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionMatch": {
+            "type": "object",
+            "properties": {
+                "match": {
+                    "type": "string",
+                    "title": "Match",
+                    "description": "Must match the regular expression.",
+                    "markdownDescription": "Must match the regular expression. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#match)"
+                }
+            },
+            "required": [
+                "match"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionNotMatch": {
+            "type": "object",
+            "properties": {
+                "notMatch": {
+                    "type": "string",
+                    "title": "Not Match",
+                    "description": "Must not match the regular expression.",
+                    "markdownDescription": "Must not match the regular expression. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notmatch)"
+                }
+            },
+            "required": [
+                "notMatch"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionIn": {
+            "type": "object",
+            "properties": {
+                "in": {
+                    "type": "array",
+                    "title": "In",
+                    "description": "Must equal one the values.",
+                    "markdownDescription": "Must equal one the values. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#in)"
+                }
+            },
+            "required": [
+                "in"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionNotIn": {
+            "type": "object",
+            "properties": {
+                "notIn": {
+                    "type": "array",
+                    "title": "Not In",
+                    "description": "Must not equal any of the values.",
+                    "markdownDescription": "Must not equal one the values. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notin)"
+                }
+            },
+            "required": [
+                "notIn"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionLess": {
+            "type": "object",
+            "properties": {
+                "less": {
+                    "type": "integer",
+                    "title": "Less",
+                    "description": "Must be less then the specified value.",
+                    "markdownDescription": "Must be less then the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#less)"
+                }
+            },
+            "required": [
+                "less"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionLessOrEquals": {
+            "type": "object",
+            "properties": {
+                "lessOrEquals": {
+                    "type": "integer",
+                    "title": "Less or Equal to",
+                    "description": "Must be less or equal to the specified value.",
+                    "markdownDescription": "Must be less or equal to the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#lessorequals)"
+                }
+            },
+            "required": [
+                "lessOrEquals"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionGreater": {
+            "type": "object",
+            "properties": {
+                "greater": {
+                    "type": "integer",
+                    "title": "Greater",
+                    "description": "Must be greater then the specified value.",
+                    "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#greater)"
+                }
+            },
+            "required": [
+                "greater"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionGreaterOrEquals": {
+            "type": "object",
+            "properties": {
+                "greaterOrEquals": {
+                    "type": "integer",
+                    "title": "Greater or Equal to",
+                    "description": "Must be greater or equal to the specified value.",
+                    "markdownDescription": "Must be greater or equal to the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#greaterorequals)"
+                }
+            },
+            "required": [
+                "greaterOrEquals"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
         }
     }
 }

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -69,6 +69,13 @@
                     "markdownDescription": "Configures the separator to use for building a qualified name. The default is `/`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingnameseparator)",
                     "default": "/"
                 },
+                "preferTargetInfo": {
+                    "type": "boolean",
+                    "title": "Prefer target info",
+                    "description": "Determines if binding prefers target info provided by the object over custom configuration. The default is false.",
+                    "markdownDescription": "Determines if binding prefers target info provided by the object over custom configuration. The default is `false`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingprefertargetinfo)",
+                    "default": false
+                },
                 "targetName": {
                     "type": "array",
                     "title": "Bind TargetName",

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -1,10 +1,11 @@
 {
-    "baseline": {
+    "Baseline": {
         "prefix": "baseline",
-        "description": "Baseline spec",
+        "description": "PSRule Baseline resource",
         "body": [
             "---",
             "# Synopsis: ${2}",
+            "apiVersion: github.com/microsoft/PSRule/v1",
             "kind: Baseline",
             "metadata:",
             "  name: ${1}",
@@ -12,17 +13,33 @@
             "  ${3}"
         ]
     },
-    "moduleConfig": {
+    "ModuleConfig": {
         "prefix": "moduleConfig",
-        "description": "Module Config spec",
+        "description": "PSRule Module Config resource",
         "body": [
             "---",
             "# Synopsis: ${2}",
+            "apiVersion: github.com/microsoft/PSRule/v1",
             "kind: ModuleConfig",
             "metadata:",
             "  name: ${1}",
             "spec:",
             "  ${3}"
+        ]
+    },
+    "Selector": {
+        "prefix": "selector",
+        "description": "PSRule Selector resource",
+        "body": [
+            "---",
+            "# Synopsis: ${2}",
+            "apiVersion: github.com/microsoft/PSRule/v1",
+            "kind: Selector",
+            "metadata:",
+            "  name: ${1}",
+            "spec:",
+            "  if:",
+            "    ${3}"
         ]
     }
 }


### PR DESCRIPTION
## PR Summary

- Added support for selectors. #206
- Updated options and language schema to support `binding.preferTargetInfo` option. #207
- Updated language schema to add `apiVersion` property. #208

Fixes #206 
Fixes #207 
Fixes #208 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
