### PR TITLE
Options schema updates #264 #265 #266

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Continue reading to see the changes included in the latest version.
     - Source locations for rules failures are detected when using the `VisualStudioCode` style.
 - General improvements:
   - Preview channel will notify that a stable version is available. [#235](https://github.com/microsoft/PSRule-vscode/issues/235)
+  - Added PSRule options schema support updates.
+    - Added `Output.Banner` option. [#264](https://github.com/microsoft/PSRule-vscode/issues/264)
+    - Improved validation for the requires option. [#265](https://github.com/microsoft/PSRule-vscode/issues/265)
+    - Added support for new style options `VisualStudioCode` and `Detect`. [#266](https://github.com/microsoft/PSRule-vscode/issues/266)
 - Engineering:
   - Bump vscode engine to v1.56.0. [#241](https://github.com/microsoft/PSRule-vscode/pull/241)
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -294,6 +294,28 @@
                     "enum": ["Detail", "Summary"],
                     "default": "Detail"
                 },
+                "banner": {
+                    "title": "Banner format",
+                    "description": "The information displayed for Assert-PSRule banner. The default is Default which includes Title, Source, and SupportLinks.",
+                    "markdownDescription": "The information displayed for Assert-PSRule banner. The default is `Default` which includes `Title`, `Source`, and `SupportLinks`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputbanner)",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": [
+                                "None",
+                                "Title",
+                                "Source",
+                                "SupportLinks",
+                                "Default",
+                                "Minimal"
+                            ]
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "default": "Default"
+                },
                 "culture": {
                     "type": "array",
                     "title": "Culture",
@@ -353,10 +375,17 @@
                 "style": {
                     "type": "string",
                     "title": "Output Style",
-                    "description": "The style that results will be presented in. The default is Client.",
-                    "markdownDescription": "The style that results will be presented in. The default is `Client`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputstyle)",
-                    "enum": ["Client", "Plain", "AzurePipelines", "GitHubActions"],
-                    "default": "Client"
+                    "description": "The style that results will be presented in. The default is Detect.",
+                    "markdownDescription": "The style that results will be presented in. The default is `Detect`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputstyle)",
+                    "enum": [
+                        "Client",
+                        "Plain",
+                        "AzurePipelines",
+                        "GitHubActions",
+                        "VisualStudioCode",
+                        "Detect"
+                    ],
+                    "default": "Detect"
                 }
             },
             "additionalProperties": false
@@ -440,8 +469,20 @@
             "description": "Specifies the required version of a module to use.",
             "markdownDescription": "Specifies the required version of a module to use. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#requires)",
             "additionalProperties": {
-                "type": "string"
-            }
+                "type": "string",
+                "title": "Version constraint",
+                "description": "Specifies a module to constrain to a specific version.",
+                "markdownDescription": "Specifies a module to constrain to a specific version. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#requires)",
+                "pattern": "^(@pre|@prerelease )?(((?:^|~|\\>=|\\>|=|\\<=|\\<)?v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\s|\\s?\\|\\|\\s?)?){1,}$"
+            },
+            "defaultSnippets": [
+                {
+                    "label": "Version constraint",
+                    "body": {
+                        "${1:Module}": "${2:'>=1.0.0'}"
+                    }
+                }
+            ]
         },
         "rule-option": {
             "type": "object",


### PR DESCRIPTION
## PR Summary

- Added PSRule options schema support updates.
  - Added `Output.Banner` option. #264
  - Improved validation for the requires option. #265
  - Added support for new style options `VisualStudioCode` and `Detect`. #266

Fixes #264 
Fixes #265 
Fixes #266 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
