### PR TITLE
Updated options and language schema #327 #328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Continue reading to see the changes included in the latest version.
 
 ## Unreleased
 
+What's changed since v1.1.0:
+
+- General improvements:
+  - Added string selector support to language schema. [#327](https://github.com/microsoft/PSRule-vscode/issues/327)
+  - Updated options schema to support PSRule v1.5.0. [#328](https://github.com/microsoft/PSRule-vscode/issues/328)
 - Engineering:
   - Bump vscode engine to v1.58.1. [#325](https://github.com/microsoft/PSRule-vscode/pull/325)
 

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -420,6 +420,24 @@
                 },
                 {
                     "$ref": "#/definitions/selectorConditionGreaterOrEquals"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionStartsWith"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionEndsWith"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionContains"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionIsString"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionIsLower"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionIsUpper"
                 }
             ]
         },
@@ -717,6 +735,122 @@
             "oneOf": [
                 {
                     "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionStartsWith": {
+            "type": "object",
+            "properties": {
+                "startsWith": {
+                    "title": "Starts with",
+                    "description": "Must start with one of the specified values.",
+                    "markdownDescription": "Must start with one of the specified values. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#startswith)",
+                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                }
+            },
+            "required": ["startsWith"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionEndsWith": {
+            "type": "object",
+            "properties": {
+                "endsWith": {
+                    "title": "Ends with",
+                    "description": "Must end with one of the specified values.",
+                    "markdownDescription": "Must end with one of the specified values. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#endswith)",
+                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                }
+            },
+            "required": ["endsWith"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionContains": {
+            "type": "object",
+            "properties": {
+                "contains": {
+                    "title": "Contains",
+                    "description": "Must contain one of the specified values.",
+                    "markdownDescription": "Must contain one of the specified values. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#contains)",
+                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                }
+            },
+            "required": ["contains"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionIsString": {
+            "type": "object",
+            "properties": {
+                "isString": {
+                    "type": "boolean",
+                    "title": "Is string",
+                    "description": "Must be a string type.",
+                    "markdownDescription": "Must be a string type. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#isstring)"
+                }
+            },
+            "required": ["isString"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionIsLower": {
+            "type": "object",
+            "properties": {
+                "isLower": {
+                    "type": "boolean",
+                    "title": "Is Lowercase",
+                    "description": "Must be a lowercase string.",
+                    "markdownDescription": "Must be a lowercase string. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#islower)"
+                }
+            },
+            "required": ["isLower"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionIsUpper": {
+            "type": "object",
+            "properties": {
+                "isUpper": {
+                    "type": "boolean",
+                    "title": "Is Uppercase",
+                    "description": "Must be an uppercase string.",
+                    "markdownDescription": "Must be an uppercase string. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#isupper)"
+                }
+            },
+            "required": ["isUpper"],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorExpressionValueMultiString": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
                 }
             ]
         }

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -473,7 +473,7 @@
                 "title": "Version constraint",
                 "description": "Specifies a module to constrain to a specific version.",
                 "markdownDescription": "Specifies a module to constrain to a specific version. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#requires)",
-                "pattern": "^(@pre|@prerelease )?(((?:^|~|\\>=|\\>|=|\\<=|\\<)?v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\s|\\s?\\|\\|\\s?)?){1,}$"
+                "pattern": "^(@pre |@prerelease )?(((?:^|~|\\>=|\\>|=|\\<=|\\<)?v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\s|\\s?\\|\\|\\s?)?){1,}$"
             },
             "defaultSnippets": [
                 {


### PR DESCRIPTION
## PR Summary

- Added string selector support to language schema. #327
- Updated options schema to support PSRule v1.5.0. #328

Fixes #327 
Fixes #328 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
