### PR TITLE
Added PSRule v1.6.0 improvements #361 #362 #363

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Continue reading to see the changes included in the latest version.
 
 What's changed since v1.2.0:
 
+- General improvements:
+  - Added YAML Rule support to language schema. [#361](https://github.com/microsoft/PSRule-vscode/issues/361)
+  - Added starter snippet for GitHub Actions workflow. [#362](https://github.com/microsoft/PSRule-vscode/issues/362)
+  - Updated options schema to support `include` option within PSRule v1.6.0. [#363](https://github.com/microsoft/PSRule-vscode/issues/363)
 - Engineering:
   - Bump vscode engine to v1.59.0. [#358](https://github.com/microsoft/PSRule-vscode/pull/358)
 

--- a/package.json
+++ b/package.json
@@ -131,6 +131,10 @@
             {
                 "language": "yaml",
                 "path": "./snippets/yaml.json"
+            },
+            {
+                "language": "yaml",
+                "path": "./snippets/github-actions.json"
             }
         ],
         "grammars": [

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "oneOf": [
         {
+            "$ref": "#/definitions/rule-v1"
+        },
+        {
             "$ref": "#/definitions/baseline-v1"
         },
         {
@@ -26,6 +29,13 @@
                 "annotations": {
                     "type": "object",
                     "title": "Annotations"
+                },
+                "tags": {
+                    "type": "object",
+                    "title": "Tags",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "required": ["name"]
@@ -355,6 +365,66 @@
                 }
             },
             "required": ["if"],
+            "additionalProperties": false
+        },
+        "rule-v1": {
+            "type": "object",
+            "title": "Rule",
+            "description": "A PSRule Rule.",
+            "markdownDescription": "A PSRule Rule. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Rules.html)",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "title": "API Version",
+                    "description": "The API Version for the PSRule resources.",
+                    "enum": ["github.com/microsoft/PSRule/v1"]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "Kind",
+                    "description": "A PSRule Rule resource.",
+                    "enum": ["Rule"]
+                },
+                "metadata": {
+                    "type": "object",
+                    "$ref": "#/definitions/resource-metadata"
+                },
+                "spec": {
+                    "type": "object",
+                    "$ref": "#/definitions/ruleSpec"
+                }
+            },
+            "required": ["apiVersion", "kind", "metadata", "spec"]
+        },
+        "ruleSpec": {
+            "type": "object",
+            "title": "Spec",
+            "description": "PSRule rule specification.",
+            "properties": {
+                "condition": {
+                    "type": "object",
+                    "$ref": "#/definitions/selectorExpression"
+                },
+                "type": {
+                    "type": "array",
+                    "title": "Type pre-condition",
+                    "description": "This rule only applies to objects that match the specifies types.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "with": {
+                    "type": "array",
+                    "title": "Selector pre-condition",
+                    "description": "This rule only applies to objects that match the specified selectors.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "required": ["condition"],
             "additionalProperties": false
         },
         "selectorExpression": {

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -136,6 +136,40 @@
             },
             "additionalProperties": false
         },
+        "include-option": {
+            "type": "object",
+            "title": "Include options",
+            "description": "Options that affect source locations imported for execution.",
+            "properties": {
+                "module": {
+                    "type": "array",
+                    "title": "Include module",
+                    "description": "Automatically include rules and resources from the specified modules.",
+                    "markdownDescription": "Automatically include rules and resources from the specified modules. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includemodule)",
+                    "items": {
+                        "type": "string",
+                        "title": "Include module",
+                        "description": "Automatically include rules and resources from the specified modules.",
+                        "markdownDescription": "Automatically include rules and resources from the specified modules. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includemodule)"
+                    },
+                    "uniqueItems": true
+                },
+                "path": {
+                    "type": "array",
+                    "title": "Include path",
+                    "description": "Automatically include rules and resources from the specified paths.",
+                    "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)",
+                    "items": {
+                        "type": "string",
+                        "title": "Include path",
+                        "description": "Automatically include rules and resources from the specified paths.",
+                        "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "additionalProperties": false
+        },
         "input-option": {
             "type": "object",
             "title": "Input options",
@@ -419,6 +453,10 @@
                             "$ref": "#/definitions/execution-option"
                         }
                     ]
+                },
+                "include": {
+                    "type": "object",
+                    "$ref": "#/definitions/include-option"
                 },
                 "input": {
                     "type": "object",

--- a/snippets/github-actions.json
+++ b/snippets/github-actions.json
@@ -1,0 +1,42 @@
+{
+    "PSRule GitHub Actions workflow": {
+        "prefix": "ps-rule-gh-action",
+        "description": "PSRule workflow snippet for GitHub Actions",
+        "body": [
+            "#",
+            "# Analyze repository with PSRule",
+            "#",
+            "",
+            "# For PSRule documentation see:",
+            "# https://aka.ms/ps-rule",
+            "",
+            "# For action details see:",
+            "# https://aka.ms/ps-rule-action",
+            "",
+            "name: Analyze repository",
+            "",
+            "# Run for main or PRs against main",
+            "on:",
+            "  push:",
+            "    branches:",
+            "    - main",
+            "  pull_request:",
+            "    branches:",
+            "    - main",
+            "",
+            "jobs:",
+            "  analyze:",
+            "    name: Analyze repository",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+            "",
+            "    - name: Checkout",
+            "      uses: actions/checkout@main",
+            "",
+            "    - name: Run PSRule analysis",
+            "      uses: Microsoft/ps-rule@main",
+            "      with:",
+            "        modules: ${1}"
+        ]
+    }
+}

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -41,5 +41,39 @@
             "  if:",
             "    ${3}"
         ]
+    },
+    "Rule with Type": {
+        "prefix": "rule-with-type",
+        "description": "PSRule Rule resource with Type pre-condition",
+        "body": [
+            "---",
+            "# Synopsis: ${2}",
+            "apiVersion: github.com/microsoft/PSRule/v1",
+            "kind: Rule",
+            "metadata:",
+            "  name: ${1}",
+            "spec:",
+            "  type:",
+            "  - ${3}",
+            "  condition:",
+            "    ${4}"
+        ]
+    },
+    "Rule with Selector": {
+        "prefix": "rule-with-selector",
+        "description": "PSRule Rule resource with Selector pre-condition",
+        "body": [
+            "---",
+            "# Synopsis: ${2}",
+            "apiVersion: github.com/microsoft/PSRule/v1",
+            "kind: Rule",
+            "metadata:",
+            "  name: ${1}",
+            "spec:",
+            "  selector:",
+            "  - ${3}",
+            "  condition:",
+            "    ${4}"
+        ]
     }
 }


### PR DESCRIPTION
## PR Summary

- General improvements:
  - Added YAML Rule support to language schema. #361
  - Added starter snippet for GitHub Actions workflow. #362
  - Updated options schema to support `include` option within PSRule v1.6.0. #363

Fixes #361 
Fixes #362 
Fixes #363

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
