### PR TITLE
Added options for PSRule v1.7.0 #395

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Continue reading to see the changes included in the latest version.
 
 What's changed since v1.3.0:
 
+- General improvements:
+  - Added options schema to support options introduced in PSRule v1.7.0. [#395](https://github.com/microsoft/PSRule-vscode/issues/395)
+    - Added support for `Input.IgnoreRepositoryCommon`, `Output.Footer`, and `Rule.IncludeLocal`.
 - Engineering:
   - Bump vscode engine to v1.60.0. [#393](https://github.com/microsoft/PSRule-vscode/pull/393)
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -195,7 +195,14 @@
                     "type": "boolean",
                     "title": "Ignore .git path",
                     "description": "Determine if files within the .git path are ignored when the -InputPath parameter is used.",
-                    "markdownDescription": "Determine if files within the `.git` path are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#ignoregitpath)",
+                    "markdownDescription": "Determine if files within the `.git` path are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#inputignoregitpath)",
+                    "default": true
+                },
+                "ignoreRepositoryCommon": {
+                    "type": "boolean",
+                    "title": "Ignore common files",
+                    "description": "Determine if common repository files are ignored when the -InputPath parameter is used.",
+                    "markdownDescription": "Determine if common repository files are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#inputignorerepositorycommon)",
                     "default": true
                 },
                 "objectPath": {
@@ -384,6 +391,21 @@
                     "enum": ["Default", "UTF8", "UTF7", "Unicode", "UTF32", "ASCII"],
                     "default": "Default"
                 },
+                "footer": {
+                    "title": "Footer format",
+                    "description": "The information displayed for Assert-PSRule footer. The default is Default which includes RuleCount, and RunInfo.",
+                    "markdownDescription": "The information displayed for Assert-PSRule footer. The default is `Default` which includes `RuleCount`, and `RunInfo`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputfooter)",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["None", "RuleCount", "RunInfo", "Default"]
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "default": "Default"
+                },
                 "format": {
                     "type": "string",
                     "title": "Output format",
@@ -533,6 +555,13 @@
                     "description": "Optionally filter to rules by name.",
                     "markdownDescription": "Optionally filter to rules by name. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#ruleinclude)",
                     "$ref": "#/definitions/rule-names"
+                },
+                "includeLocal": {
+                    "type": "boolean",
+                    "title": "Include local",
+                    "description": "Automatically include all local rules in the search path unless they have been explicitly excluded.",
+                    "markdownDescription": "Automatically include all local rules in the search path unless they have been explicitly excluded. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#ruleincludelocal)",
+                    "default": false
                 },
                 "exclude": {
                     "type": "array",


### PR DESCRIPTION
## PR Summary

- Added options schema to support options introduced in PSRule v1.7.0.
  - Added support for `Input.IgnoreRepositoryCommon`, `Output.Footer`, and `Rule.IncludeLocal`.

Fixes #395

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
