### PR TITLE
Added JSON resource support #475 #476 #304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Continue reading to see the changes included in the latest version.
 
 What's changed since v1.4.0:
 
+- General improvements:
+  - Added `Rule.Baseline` option configuration the default baseline with module configuration. [#475](https://github.com/microsoft/PSRule-vscode/issues/475)
+  - Added support for resources within `.Rule.json`, `.Rule.jsonc`, and `.Rule.yml` files. [#476](https://github.com/microsoft/PSRule-vscode/issues/476)
+  - Configured workspace trust. [#304](https://github.com/microsoft/PSRule-vscode/issues/304)
+    - Currently the extension relies on PowerShell which only works when the workspace is trusted.
 - Engineering:
   - Bump vscode engine to v1.62.0. [#473](https://github.com/microsoft/PSRule-vscode/pull/473)
 

--- a/docs/Example.Rule.jsonc
+++ b/docs/Example.Rule.jsonc
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+[
+    {
+        // Synopsis: This is an example baseline
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Baseline",
+        "metadata": {
+            "name": "Module4"
+        },
+        "spec": {
+            "binding": {
+                "field": {
+                    "kind": ["Id"],
+                    "uniqueIdentifer": ["AlternateName", "Id"]
+                },
+                "targetName": ["AlternateName"],
+                "targetType": ["Kind"]
+            },
+            "configuration": {
+                "ruleConfig1": "Test"
+            },
+            "rule": {
+                "include": ["M4.Rule1"]
+            }
+        }
+    },
+    {
+        // Synopsis: This is an example baseline
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Baseline",
+        "metadata": {
+            "name": "Baseline2"
+        },
+        "spec": {
+            "binding": {
+                "targetName": ["AlternateName"],
+                "targetType": ["Kind"]
+            },
+            "configuration": {
+                "ruleConfig2": "Test3"
+            },
+            "rule": {
+                "include": ["M4.Rule1"]
+            }
+        }
+    },
+    {
+        // Synopsis: This is an example baseline
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Baseline",
+        "metadata": {
+            "name": "Baseline3"
+        },
+        "spec": {
+            "binding": {
+                "field": {
+                    "AlternativeType": ["AlternateName"]
+                },
+                "targetName": ["AlternateName"],
+                "targetType": ["Kind"]
+            },
+            "configuration": {
+                "ruleConfig2": "Test3"
+            },
+            "rule": {
+                "include": ["M4.Rule1"]
+            }
+        }
+    }
+]

--- a/package.json
+++ b/package.json
@@ -39,10 +39,18 @@
         "onLanguage:powershell",
         "workspaceContains:/ps-rule.yaml",
         "workspaceContains:**/*.Rule.yaml",
+        "workspaceContains:**/*.Rule.yml",
+        "workspaceContains:**/*.Rule.json",
+        "workspaceContains:**/*.Rule.jsonc",
         "workspaceContains:**/*.Rule.ps1",
         "onCommand:workbench.action.tasks.runTask"
     ],
     "main": "./out/dist/main.js",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": false
+        }
+    },
     "contributes": {
         "configuration": [
             {
@@ -187,6 +195,20 @@
             {
                 "fileMatch": "**/*.Rule.yaml",
                 "url": "./schemas/PSRule-language.schema.json"
+            },
+            {
+                "fileMatch": "**/*.Rule.yml",
+                "url": "./schemas/PSRule-language.schema.json"
+            }
+        ],
+        "jsonValidation": [
+            {
+                "fileMatch": "*.Rule.json",
+                "url": "./schemas/PSRule-resources.schema.json"
+            },
+            {
+                "fileMatch": "*.Rule.jsonc",
+                "url": "./schemas/PSRule-resources.schema.json"
             }
         ],
         "problemMatchers": [

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -206,6 +206,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "rule": {
+                    "type": "object",
+                    "title": "Rule",
+                    "description": "A filter for included or excluded rules.",
+                    "properties": {
+                        "baseline": {
+                            "type": "string",
+                            "title": "Baseline",
+                            "description": "The name of a baseline to use.",
+                            "markdownDescription": "The name of a baseline to use. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#rulebaseline)",
+                            "$ref": "#/definitions/rule-names"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false

--- a/schemas/PSRule-resources.schema.json
+++ b/schemas/PSRule-resources.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PSRule resources",
+    "description": "A schema for PSRule resources.",
+    "type": "array",
+    "items": {
+        "anyOf": [
+            {
+                "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/rule-v1"
+            },
+            {
+                "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/baseline-v1"
+            },
+            {
+                "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/moduleConfig-v1"
+            },
+            {
+                "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/selector-v1"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added `Rule.Baseline` option configuration the default baseline with module configuration. #475
- Added support for resources within `.Rule.json`, `.Rule.jsonc`, and `.Rule.yml` files. #476
- Configured workspace trust. #304
  - Currently the extension relies on PowerShell which only works when the workspace is trusted.

Fixes #475 
Fixes #476 
Fixes #304 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
