### PR TITLE
Fix issue with schema workflow adding PSRule submodule

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -46,3 +46,5 @@ jobs:
           title: Sync PSRule Schema
           body: 'Updates to JSON schema files'
           delete-branch: true
+          add-paths: |
+            *.schema.json

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -47,4 +47,4 @@ jobs:
           body: 'Updates to JSON schema files'
           delete-branch: true
           add-paths: |
-            *.schema.json
+            schemas/*.schema.json


### PR DESCRIPTION
## PR Summary

Ensuring only `*.schema.json` files are added and commited. 

Caught this issue in this test PR: https://github.com/microsoft/PSRule-vscode/pull/599, where PSRule was being added as a submodule. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
