### PR TITLE
Added baseline option #770

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -27,7 +29,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -47,7 +51,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -55,7 +61,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -75,7 +83,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -83,7 +93,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -103,7 +115,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -111,7 +125,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -132,7 +148,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -140,7 +158,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -155,7 +175,9 @@
                 "panel": "dedicated",
                 "clear": true
             },
-            "problemMatcher": ["$tsc"]
+            "problemMatcher": [
+                "$tsc"
+            ]
         },
         {
             "label": "Analyze repository",
@@ -173,7 +195,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             },
@@ -181,7 +205,9 @@
                 "options": {
                     "shell": {
                         "executable": "pwsh",
-                        "args": ["-c"]
+                        "args": [
+                            "-c"
+                        ]
                     }
                 }
             }
@@ -209,7 +235,27 @@
                 "panel": "dedicated",
                 "clear": true
             },
-            "problemMatcher": ["$tsc"]
+            "problemMatcher": [
+                "$tsc"
+            ]
+        },
+        {
+            "type": "PSRule",
+            "problemMatcher": [
+                "$PSRule"
+            ],
+            "outcome": [
+                "Fail",
+                "Error",
+                "Pass"
+            ],
+            "label": "PSRule: Run analysis",
+            "detail": "Run analysis on files within the repository.",
+            "presentation": {
+                "focus": false,
+                "panel": "dedicated",
+                "clear": true
+            }
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,17 @@ Continue reading to see the changes included in the latest version.
 
 What's changed since v2.2.0:
 
+- General improvements:
+  - Added configuration option for baseline by @BernieWhite.
+    [#770](https://github.com/microsoft/PSRule-vscode/issues/770)
+    - Configure the default baseline in the extension settings.
+    - Baseline can be overridden using the `baseline` property on a PSRule task.
 - Engineering:
   - Updated PSRule schema files.
     [#767](https://github.com/microsoft/PSRule-vscode/pull/767)
   - Bump vscode-languageclient v8.0.2.
     [#777](https://github.com/microsoft/PSRule-vscode/pull/777)
-  - Bumps @types/vscode to v1.69.0.
+  - Bumps vscode engine to v1.69.0.
     [#772](https://github.com/microsoft/PSRule-vscode/pull/772)
 
 ## v2.2.0

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Name                                            | Description
 `PSRule.notifications.showChannelUpgrade`       | Determines if a notification to switch to the stable channel is shown on start up.
 `PSRule.notifications.showPowerShellExtension`  | Determines if a notification to install the PowerShell extension is shown on start up.
 `PSRule.output.as`                              | Configures the output of analysis tasks, either summary or detailed.
+`PSRule.rule.baseline`                          | The name of the default baseline to use for executing rules. This setting can be overridden on individual PSRule tasks.
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,12 @@
                             "Summary"
                         ],
                         "scope": "window"
+                    },
+                    "PSRule.rule.baseline": {
+                        "type": "string",
+                        "default": null,
+                        "description": "The name of the default baseline to use for executing rules. This setting can be overridden on individual PSRule tasks.",
+                        "scope": "window"
                     }
                 }
             }
@@ -154,7 +160,7 @@
                     },
                     "baseline": {
                         "type": "string",
-                        "description": "The name of a PSRule baseline to use. Baselines can be used from modules or specified in a separate file."
+                        "description": "The name of a PSRule baseline to use. Baselines can be used from modules or specified in a separate file. This option overrides the default baseline setting set for a workspace or user."
                     },
                     "modules": {
                         "type": "array",

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -5,8 +5,16 @@
 # Please see the documentation for all configuration options:
 # https://aka.ms/ps-rule/options
 
+repository:
+  url: https://github.com/microsoft/PSRule-vscode
+
 requires:
-  PSRule: '@pre >=2.0.0'
+  PSRule: '@pre >=2.2.0'
+  PSRule.Rules.MSFT.OSS: '@pre >=1.0.1'
+
+include:
+  module:
+  - PSRule.Rules.MSFT.OSS
 
 output:
   culture:

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -218,6 +218,10 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
             };
         }
 
+        const executionNotProcessedWarning = configuration.get().executionNotProcessedWarning;
+        const outputAs = configuration.get().outputAs;
+        const ruleBaseline = configuration.get().ruleBaseline;
+
         function getTaskName() {
             return name;
         }
@@ -241,6 +245,8 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
             // Baseline
             if (baseline !== undefined && baseline !== '') {
                 params += ` -Baseline '${baseline}'`;
+            } else if (ruleBaseline !== undefined && ruleBaseline !== '') {
+                params += ` -Baseline '${ruleBaseline}'`;
             }
 
             // Modules
@@ -271,8 +277,6 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
         }
 
         const taskName = getTaskName();
-        const executionNotProcessedWarning = configuration.get().executionNotProcessedWarning;
-        const outputAs = configuration.get().outputAs;
 
         if (!pwsh.isActive) {
             return new vscode.Task(

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -6,7 +6,7 @@ import { configuration, ConfigurationManager, ISetting, OutputAs } from '../../c
 
 suite('ConfigurationManager tests', () => {
     test('Defaults', () => {
-        const config = new ConfigurationManager(undefined);
+        const config = new ConfigurationManager(undefined, 'PSRule_unit_test');
 
         assert.equal(config.get().codeLensRuleDocumentationLinks, false);
         assert.equal(config.get().documentationCustomSnippetPath, undefined);
@@ -18,5 +18,6 @@ suite('ConfigurationManager tests', () => {
         assert.equal(config.get().outputAs, OutputAs.Summary);
         assert.equal(config.get().notificationsShowChannelUpgrade, true);
         assert.equal(config.get().notificationsShowPowerShellExtension, true);
+        assert.equal(config.get().ruleBaseline, undefined);
     });
 });


### PR DESCRIPTION
## PR Summary

- Added configuration option for baseline.
  - Configure the default baseline in the extension settings.
  - Baseline can be overridden using the `baseline` property on a PSRule task.

Fixes #770

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
