### PR TITLE
Release v2.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ Capture any error messages and or terminal output.
 
 **Extension version:**
 
-- Version: **[e.g. 2.2.0]**
+- Version: **[e.g. 2.3.0]**
 
 **PSRule module version:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Continue reading to see the changes included in the latest version.
 
 ## Unreleased
 
+## v2.3.0
+
 What's changed since v2.2.0:
 
 - General improvements:
@@ -26,8 +28,8 @@ What's changed since v2.2.0:
     [#767](https://github.com/microsoft/PSRule-vscode/pull/767)
   - Bump vscode-languageclient v8.0.2.
     [#777](https://github.com/microsoft/PSRule-vscode/pull/777)
-  - Bumps vscode engine to v1.69.0.
-    [#772](https://github.com/microsoft/PSRule-vscode/pull/772)
+  - Bumps vscode engine to v1.69.1.
+    [#797](https://github.com/microsoft/PSRule-vscode/pull/797)
 
 ## v2.2.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v2.2.0:

- General improvements:
  - Added configuration option for baseline by @BernieWhite.
    [#770](https://github.com/microsoft/PSRule-vscode/issues/770)
    - Configure the default baseline in the extension settings.
    - Baseline can be overridden using the `baseline` property on a PSRule task.
- Engineering:
  - Updated PSRule schema files.
    [#767](https://github.com/microsoft/PSRule-vscode/pull/767)
  - Bump vscode-languageclient v8.0.2.
    [#777](https://github.com/microsoft/PSRule-vscode/pull/777)
  - Bumps vscode engine to v1.69.1.
    [#797](https://github.com/microsoft/PSRule-vscode/pull/797)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
