### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Continue reading to see the changes included in the latest version.
 
 ## Unreleased
 
+## v2.8.0
+
 What's changed since v2.7.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.7.0:

- Engineering:
  - Updated PSRule schema files.
    [#1060](https://github.com/microsoft/PSRule-vscode/pull/1060)
    [#1062](https://github.com/microsoft/PSRule-vscode/pull/1062)
  - Bump vscode engine to v1.76.0.
    [#1036](https://github.com/microsoft/PSRule-vscode/pull/1036)
  - Bump mocha to v10.2.0.
    [#957](https://github.com/microsoft/PSRule-vscode/pull/957)
  - Bump fs-extra to v11.1.1.
    [#1058](https://github.com/microsoft/PSRule-vscode/pull/1058)
  - Bump glob to v8.1.0.
    [#990](https://github.com/microsoft/PSRule-vscode/pull/990)
  - Bump typescript to v5.0.2.
    [#1053](https://github.com/microsoft/PSRule-vscode/pull/1053)
  - Bump minimist to v1.2.8.
    [#1014](https://github.com/microsoft/PSRule-vscode/pull/1014)
  - Bump vscode-languageclient to v8.1.0.
    [#1021](https://github.com/microsoft/PSRule-vscode/pull/1021)
  - Bump @vscode/test-electron to v2.3.0.
    [#1035](https://github.com/microsoft/PSRule-vscode/pull/1035)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
