### PR TITLE
Add config for excluded and suppressed rules #1068

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,34 +3,41 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-            "outFiles": ["${workspaceFolder}/out/**/*.js"],
-            "preLaunchTask": "Compile"
-        },
-        {
-            "name": "Extension Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "presentation": {
-                "hidden": false,
-                "group": "",
-                "order": 1
-            },
-            "internalConsoleOptions": "openOnSessionStart",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionTestsPath=${workspaceFolder}/out/dist/test/suite/index"
-            ],
-            "outFiles": ["${workspaceFolder}/out/dist/test/**/*.js"],
-            "preLaunchTask": "Compile"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extension=bewhite.psrule-vscode-preview,bewhite.psrule-vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "Compile"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "presentation": {
+        "hidden": false,
+        "group": "",
+        "order": 1
+      },
+      "internalConsoleOptions": "openOnSessionStart",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/dist/test/suite/index"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/dist/test/**/*.js"
+      ],
+      "preLaunchTask": "Compile"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Continue reading to see the changes included in the latest version.
 
 What's changed since v2.8.0:
 
+- New features:
+  - Added configuration to tune logging for excluded or suppressed rules by @BernieWhite.
+    [#1068](https://github.com/microsoft/PSRule-vscode/issues/1068)
+    - Use these options to reduce output noise when testing in Visual Studio Code.
+    - The `PSRule.execution.ruleExcluded` setting configures excluded rules.
+    - The `PSRule.execution.ruleSuppressed` setting configures suppressed rules.
 - Engineering:
   - Bump vscode engine to v1.77.0.
     [#1072](https://github.com/microsoft/PSRule-vscode/pull/1072)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Name                                            | Description
 `PSRule.documentation.customSnippetPath`        | The path to a file containing a rule documentation snippet. When not set, built-in PSRule snippets will be used.
 `PSRule.documentation.snippet`                  | The name of a snippet to use when creating new rule documentation. By default, the built-in `Rule Doc` snippet will be used.
 `PSRule.execution.notProcessedWarning`          | Warn when objects are not processed by any rule.
+`PSRule.execution.ruleExcluded`                 | Determines how to handle excluded rules. When set to `None`, PSRule will use the default (`Ignore`), unless set by PSRule options.
+`PSRule.execution.ruleSuppressed`               | Determines how to handle suppressed rules. When set to `None`, PSRule will use the default (`Warn`), unless set by PSRule options.
 `PSRule.experimental.enabled`                   | Enables experimental features in the PSRule extension.
 `PSRule.notifications.showChannelUpgrade`       | Determines if a notification to switch to the stable channel is shown on start up.
 `PSRule.notifications.showPowerShellExtension`  | Determines if a notification to install the PowerShell extension is shown on start up.
@@ -141,7 +143,6 @@ This project is [licensed under the MIT License][license].
 
 [issue]: https://github.com/Microsoft/PSRule-vscode/issues
 [discussion]: https://github.com/microsoft/PSRule-vscode/discussions
-[ci-badge]: https://dev.azure.com/bewhite/PSRule-vscode/_apis/build/status/PSRule-vscode-CI?branchName=main
 [vscode-ext-gallery]: https://code.visualstudio.com/docs/editor/extension-gallery
 [ext-preview]: https://marketplace.visualstudio.com/items?itemName=bewhite.psrule-vscode-preview
 [ext-preview-version-badge]: https://vsmarketplacebadges.dev/version/bewhite.psrule-vscode-preview.png
@@ -151,6 +152,5 @@ This project is [licensed under the MIT License][license].
 [ext-stable-installs-badge]: https://vsmarketplacebadges.dev/installs-short/bewhite.psrule-vscode.png
 [module-version-badge]: https://img.shields.io/powershellgallery/v/PSRule.png?label=PowerShell%20Gallery&color=brightgreen
 [contribution guide]: https://github.com/Microsoft/PSRule-vscode/blob/main/CONTRIBUTING.md
-[change log]: https://github.com/Microsoft/PSRule-vscode/blob/main/CHANGELOG.md
 [license]: https://github.com/Microsoft/PSRule-vscode/blob/main/LICENSE
 [ps-rule.yaml]: https://aka.ms/ps-rule/options

--- a/package.json
+++ b/package.json
@@ -45,12 +45,7 @@
     "workspaceContains:**/*.Rule.json",
     "workspaceContains:**/*.Rule.jsonc",
     "workspaceContains:**/*.Rule.ps1",
-    "onCommand:workbench.action.tasks.runTask",
-    "onCommand:PSRule.createOrEditDocumentation",
-    "onCommand:PSRule.openOptionsFile",
-    "onCommand:PSRule.createOptionsFile",
-    "onCommand:PSRule.configureSettings",
-    "onCommand:PSRule.walkthroughCopySnippet"
+    "onCommand:workbench.action.tasks.runTask"
   ],
   "main": "./out/dist/main.js",
   "capabilities": {
@@ -129,6 +124,40 @@
             "default": false,
             "description": "Warn when objects are not processed by any rule.",
             "scope": "window"
+          },
+          "PSRule.execution.ruleExcluded": {
+            "type": "string",
+            "default": "None",
+            "markdownDescription": "Determines how to handle [excluded rules](https://aka.ms/ps-rule/options#executionruleexcluded). When set to `None`, PSRule will use the default (`Ignore`), unless set by [PSRule options](https://aka.ms/ps-rule/options#executionruleexcluded).",
+            "markdownEnumDescriptions": [
+              "Excluded rules will not generate any notifications unless overridden.",
+              "Excluded rules will not generate any notifications.",
+              "Excluded rules will generate a warning.",
+              "Excluded rules will generate an error."
+            ],
+            "enum": [
+              "None",
+              "Ignore",
+              "Warn",
+              "Error"
+            ]
+          },
+          "PSRule.execution.ruleSuppressed": {
+            "type": "string",
+            "default": "None",
+            "markdownDescription": "Determines how to handle [suppressed rules](https://aka.ms/ps-rule/options#executionrulesuppressed). When set to `None`, PSRule will use the default (`Warn`), unless set by [PSRule options](https://aka.ms/ps-rule/options#executionrulesuppressed).",
+            "markdownEnumDescriptions": [
+              "Suppressed rules will generate a warning unless overridden.",
+              "Suppressed rules will not generate any notifications.",
+              "Suppressed rules will generate a warning.",
+              "Suppressed rules will generate an error."
+            ],
+            "enum": [
+              "None",
+              "Ignore",
+              "Warn",
+              "Error"
+            ]
           },
           "PSRule.experimental.enabled": {
             "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,28 @@ export enum OutputAs {
     Summary = 'Summary',
 }
 
+export enum ExecutionActionPreference {
+    /**
+     * No preference.
+     * This will inherit from the default.
+     */
+    None = 'None',
+
+    /**
+     * Continue to execute silently.
+     */
+    Ignore = 'Ignore',
+    /**
+     * Continue to execute but log a warning.
+     */
+    Warn = 'Warn',
+
+    /**
+     * Generate an error.
+     */
+    Error = 'Error',
+}
+
 /**
  * PSRule extension settings.
  */
@@ -23,7 +45,13 @@ export interface ISetting {
     documentationSnippet: string;
     documentationPath: string | undefined;
     documentationLocalePath: string;
+
+    /**
+     * Execution options
+     */
     executionNotProcessedWarning: boolean;
+    executionRuleExcluded: ExecutionActionPreference;
+    executionRuleSuppressed: ExecutionActionPreference;
 
     /**
      * Determines if experimental features are enabled.
@@ -49,6 +77,8 @@ const globalDefaults: ISetting = {
     documentationPath: undefined,
     documentationLocalePath: env.language,
     executionNotProcessedWarning: false,
+    executionRuleExcluded: ExecutionActionPreference.None,
+    executionRuleSuppressed: ExecutionActionPreference.None,
     experimentalEnabled: false,
     outputAs: OutputAs.Summary,
     notificationsShowChannelUpgrade: true,
@@ -127,14 +157,16 @@ export class ConfigurationManager {
         this.current.codeLensRuleDocumentationLinks = !experimental
             ? false
             : config.get<boolean>(
-                  'codeLens.ruleDocumentationLinks',
-                  this.default.codeLensRuleDocumentationLinks
-              );
+                'codeLens.ruleDocumentationLinks',
+                this.default.codeLensRuleDocumentationLinks
+            );
 
         this.current.executionNotProcessedWarning = config.get<boolean>(
             'execution.notProcessedWarning',
             this.default.executionNotProcessedWarning
         );
+        this.current.executionRuleExcluded = config.get<ExecutionActionPreference>('execution.ruleExcluded', this.default.executionRuleExcluded);
+        this.current.executionRuleSuppressed = config.get<ExecutionActionPreference>('execution.ruleSuppressed', this.default.executionRuleSuppressed);
 
         this.current.outputAs = config.get<OutputAs>('output.as', this.default.outputAs);
 

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import { configuration, ConfigurationManager, ISetting, OutputAs } from '../../configuration';
+import { ConfigurationManager, ExecutionActionPreference, OutputAs } from '../../configuration';
 
 suite('ConfigurationManager tests', () => {
     test('Defaults', () => {
@@ -14,6 +14,8 @@ suite('ConfigurationManager tests', () => {
         assert.equal(config.get().documentationPath, undefined);
         assert.equal(config.get().documentationSnippet, 'Rule Doc');
         assert.equal(config.get().executionNotProcessedWarning, false);
+        assert.equal(config.get().executionRuleExcluded, ExecutionActionPreference.None);
+        assert.equal(config.get().executionRuleSuppressed, ExecutionActionPreference.None);
         assert.equal(config.get().experimentalEnabled, false);
         assert.equal(config.get().outputAs, OutputAs.Summary);
         assert.equal(config.get().notificationsShowChannelUpgrade, true);


### PR DESCRIPTION
## PR Summary

- Added configuration to tune logging for excluded or suppressed rules by @BernieWhite.
  - Use these options to reduce output noise when testing in Visual Studio Code.
  - The `PSRule.execution.ruleExcluded` setting configures excluded rules.
  - The `PSRule.execution.ruleSuppressed` setting configures suppressed rules.

Fixes #1068 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
