### PR TITLE
Added support for unprocessed object option #1127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ What's changed since v2.8.0:
     - The `PSRule.execution.ruleSuppressed` setting configures suppressed rules.
   - Add running analysis to getting started walkthrough by @BernieWhite.
     [#1093](https://github.com/microsoft/PSRule-vscode/issues/1093)
+  - Added support for new unprocessed object option by @BernieWhite.
+    [#1127](https://github.com/microsoft/PSRule-vscode/issues/1127)
+    - The `PSRule.execution.unprocessedObject` setting configures what happens when objects are not processed.
+    - The `PSRule.execution.notProcessedWarning` setting has been deprecated inline with PSRule support.
+    - For more information see [deprecations](https://aka.ms/ps-rule/deprecations#execution-options).
 - Engineering:
   - Updated PSRule schema files.
     [#1092](https://github.com/microsoft/PSRule-vscode/pull/1092)

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ Name                                            | Description
 `PSRule.documentation.localePath`               | The locale path to use for locating rule documentation. The VS Code locale will be used by default.
 `PSRule.documentation.customSnippetPath`        | The path to a file containing a rule documentation snippet. When not set, built-in PSRule snippets will be used.
 `PSRule.documentation.snippet`                  | The name of a snippet to use when creating new rule documentation. By default, the built-in `Rule Doc` snippet will be used.
-`PSRule.execution.notProcessedWarning`          | Warn when objects are not processed by any rule.
+`PSRule.execution.notProcessedWarning`          | Warn when objects are not processed by any rule. This option is deprecated and replaced by `PSRule.execution.unprocessedObject`.
 `PSRule.execution.ruleExcluded`                 | Determines how to handle excluded rules. When set to `None`, PSRule will use the default (`Ignore`), unless set by PSRule options.
 `PSRule.execution.ruleSuppressed`               | Determines how to handle suppressed rules. When set to `None`, PSRule will use the default (`Warn`), unless set by PSRule options.
+`PSRule.execution.unprocessedObject`            | Determines how to report objects that are not processed by any rule. When set to `None`, PSRule will use the default (`Warn`), unless set by PSRule options.
 `PSRule.experimental.enabled`                   | Enables experimental features in the PSRule extension.
 `PSRule.notifications.showChannelUpgrade`       | Determines if a notification to switch to the stable channel is shown on start up.
 `PSRule.notifications.showPowerShellExtension`  | Determines if a notification to install the PowerShell extension is shown on start up.

--- a/package.json
+++ b/package.json
@@ -133,8 +133,9 @@
           "PSRule.execution.notProcessedWarning": {
             "type": "boolean",
             "default": false,
-            "description": "Warn when objects are not processed by any rule.",
-            "scope": "window"
+            "description": "Warn when objects are not processed by any rule. Supported on PSRule < v3.",
+            "scope": "window",
+            "markdownDeprecationMessage": "This option is replaced by [Unprocessed Object](https://aka.ms/ps-rule/options#executionunprocessedobject) from PSRule v2.9.0. This option will be removed from PSRule v3."
           },
           "PSRule.execution.ruleExcluded": {
             "type": "string",
@@ -151,7 +152,8 @@
               "Ignore",
               "Warn",
               "Error"
-            ]
+            ],
+            "scope": "application"
           },
           "PSRule.execution.ruleSuppressed": {
             "type": "string",
@@ -168,7 +170,26 @@
               "Ignore",
               "Warn",
               "Error"
-            ]
+            ],
+            "scope": "application"
+          },
+          "PSRule.execution.unprocessedObject": {
+            "type": "string",
+            "default": "None",
+            "markdownDescription": "Determines how to report objects that are [not processed by any rule](https://aka.ms/ps-rule/options#executionunprocessedobject). When set to `None`, PSRule will use the default (`Warn`), unless set by [PSRule options](https://aka.ms/ps-rule/options#executionunprocessedobject).",
+            "markdownEnumDescriptions": [
+              "Suppressed rules will generate a warning unless overridden.",
+              "Suppressed rules will not generate any notifications.",
+              "Suppressed rules will generate a warning.",
+              "Suppressed rules will generate an error."
+            ],
+            "enum": [
+              "None",
+              "Ignore",
+              "Warn",
+              "Error"
+            ],
+            "scope": "application"
           },
           "PSRule.experimental.enabled": {
             "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -49,9 +49,10 @@ export interface ISetting {
     /**
      * Execution options
      */
-    executionNotProcessedWarning: boolean;
+    executionNotProcessedWarning: boolean | undefined;
     executionRuleExcluded: ExecutionActionPreference;
     executionRuleSuppressed: ExecutionActionPreference;
+    executionUnprocessedObject: ExecutionActionPreference;
 
     /**
      * Determines if experimental features are enabled.
@@ -76,9 +77,10 @@ const globalDefaults: ISetting = {
     documentationSnippet: 'Rule Doc',
     documentationPath: undefined,
     documentationLocalePath: env.language,
-    executionNotProcessedWarning: false,
+    executionNotProcessedWarning: undefined,
     executionRuleExcluded: ExecutionActionPreference.None,
     executionRuleSuppressed: ExecutionActionPreference.None,
+    executionUnprocessedObject: ExecutionActionPreference.None,
     experimentalEnabled: false,
     outputAs: OutputAs.Summary,
     notificationsShowChannelUpgrade: true,
@@ -161,12 +163,10 @@ export class ConfigurationManager {
                 this.default.codeLensRuleDocumentationLinks
             );
 
-        this.current.executionNotProcessedWarning = config.get<boolean>(
-            'execution.notProcessedWarning',
-            this.default.executionNotProcessedWarning
-        );
+        this.current.executionNotProcessedWarning = config.get<boolean>('execution.notProcessedWarning');
         this.current.executionRuleExcluded = config.get<ExecutionActionPreference>('execution.ruleExcluded', this.default.executionRuleExcluded);
         this.current.executionRuleSuppressed = config.get<ExecutionActionPreference>('execution.ruleSuppressed', this.default.executionRuleSuppressed);
+        this.current.executionUnprocessedObject = config.get<ExecutionActionPreference>('execution.unprocessedObject', this.default.executionUnprocessedObject);
 
         this.current.outputAs = config.get<OutputAs>('output.as', this.default.outputAs);
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -221,6 +221,7 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
         const executionNotProcessedWarning = configuration.get().executionNotProcessedWarning;
         const executionRuleExcluded = configuration.get().executionRuleExcluded;
         const executionRuleSuppressed = configuration.get().executionRuleSuppressed;
+        const executionUnprocessedObject = configuration.get().executionUnprocessedObject;
         const outputAs = configuration.get().outputAs;
         const ruleBaseline = configuration.get().ruleBaseline;
 
@@ -300,10 +301,13 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
             PSRULE_OUTPUT_AS: outputAs,
             PSRULE_OUTPUT_CULTURE: vscode.env.language,
             PSRULE_OUTPUT_BANNER: 'Minimal',
-            PSRULE_EXECUTION_NOTPROCESSEDWARNING: executionNotProcessedWarning
-                ? 'true'
-                : 'false',
         };
+
+        if (executionNotProcessedWarning !== undefined) {
+            taskEnv.PSRULE_EXECUTION_NOTPROCESSEDWARNING = executionNotProcessedWarning
+                ? 'true'
+                : 'false';
+        }
 
         if (executionRuleExcluded !== undefined && executionRuleExcluded !== ExecutionActionPreference.None) {
             taskEnv.PSRULE_EXECUTION_RULEEXCLUDED = executionRuleExcluded;
@@ -311,6 +315,10 @@ export class PSRuleTaskProvider implements vscode.TaskProvider {
 
         if (executionRuleSuppressed !== undefined && executionRuleSuppressed !== ExecutionActionPreference.None) {
             taskEnv.PSRULE_EXECUTION_RULESUPPRESSED = executionRuleSuppressed;
+        }
+
+        if (executionUnprocessedObject !== undefined && executionUnprocessedObject !== ExecutionActionPreference.None) {
+            taskEnv.PSRULE_EXECUTION_UNPROCESSEDOBJECT = executionUnprocessedObject;
         }
 
         // Return the task instance.

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -13,9 +13,10 @@ suite('ConfigurationManager tests', () => {
         assert.equal(config.get().documentationLocalePath, 'en');
         assert.equal(config.get().documentationPath, undefined);
         assert.equal(config.get().documentationSnippet, 'Rule Doc');
-        assert.equal(config.get().executionNotProcessedWarning, false);
+        assert.equal(config.get().executionNotProcessedWarning, undefined);
         assert.equal(config.get().executionRuleExcluded, ExecutionActionPreference.None);
         assert.equal(config.get().executionRuleSuppressed, ExecutionActionPreference.None);
+        assert.equal(config.get().executionUnprocessedObject, ExecutionActionPreference.None);
         assert.equal(config.get().experimentalEnabled, false);
         assert.equal(config.get().outputAs, OutputAs.Summary);
         assert.equal(config.get().notificationsShowChannelUpgrade, true);


### PR DESCRIPTION
## PR Summary

- Added support for new unprocessed object option.
  - The `PSRule.execution.unprocessedObject` setting configures what happens when objects are not processed.
  - The `PSRule.execution.notProcessedWarning` setting has been deprecated inline with PSRule support.
  - For more information see [deprecations](https://aka.ms/ps-rule/deprecations#execution-options).

Fixes #1127 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section
