### PR TITLE
Add pinned dependencies.

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -11,71 +11,71 @@
 
 name: Analyze
 on:
-  push:
-    branches: [main, 'release/*', 'dependencies/*']
-  pull_request:
-    branches: [main, 'release/*']
-  schedule:
-    - cron: '54 20 * * 0' # At 08:54 PM, on Sunday each week
-  workflow_dispatch: {}
+    push:
+        branches: [main, 'release/*', 'dependencies/*']
+    pull_request:
+        branches: [main, 'release/*']
+    schedule:
+        - cron: '54 20 * * 0' # At 08:54 PM, on Sunday each week
+    workflow_dispatch: {}
 
 permissions: {}
 
 jobs:
-  oss:
-    name: Analyze with PSRule
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    oss:
+        name: Analyze with PSRule
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Run PSRule analysis
-        uses: microsoft/ps-rule@v2.8.1
-        with:
-          modules: PSRule.Rules.MSFT.OSS
-          prerelease: true
+            - name: Run PSRule analysis
+              uses: microsoft/ps-rule@v2.8.1
+              with:
+                  modules: PSRule.Rules.MSFT.OSS
+                  prerelease: true
 
-  devskim:
-    name: Analyze with DevSkim
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    devskim:
+        name: Analyze with DevSkim
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Run DevSkim scanner
-        uses: microsoft/DevSkim-Action@v1
-        with:
-          directory-to-scan: .
+            - name: Run DevSkim scanner
+              uses: microsoft/DevSkim-Action@a6b6966a33b497cd3ae2ebc406edf8f4cc2feec6 # v1.0.15
+              with:
+                  directory-to-scan: .
 
-      - name: Upload results to security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: devskim-results.sarif
+            - name: Upload results to security tab
+              uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+              with:
+                  sarif_file: devskim-results.sarif
 
-  codeql:
-    name: Analyze with CodeQL
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    codeql:
+        name: Analyze with CodeQL
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: 'javascript'
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+              with:
+                  languages: 'javascript'
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8


### PR DESCRIPTION
Pinning dependencies in a PR description is important for several reasons, particularly when using GitHub Actions or other external dependencies. Here’s why:  

### **1. Security & Integrity** 

Pinning dependencies to a commit SHA ensures that your workflow always runs the exact same version of an action. If an action is referenced by a tag (e.g., `@v9`), the maintainers can update that tag to point to a different commit, potentially introducing breaking changes or security vulnerabilities.  

### **2. Stability & Consistency** 

Pinning to a SHA prevents unexpected behavior due to updates. If an action is updated and introduces a bug, it could break your workflow. Using a pinned SHA guarantees your workflow remains stable until you intentionally update it.  

### **3. Auditing & Compliance** 

Some security and compliance policies require projects to use immutable references for dependencies. Pinning SHAs ensures that the same verified code is always executed, making audits and security reviews easier.  


Thanks